### PR TITLE
Fix `IsSuspended` wrongly `true` at normal program exit/finish.

### DIFF
--- a/Serpent/Python.cs
+++ b/Serpent/Python.cs
@@ -66,10 +66,9 @@ public sealed class Python
         }
 
         // Check if we've suspended
-        if (_instance.GetAsyncState() == AsyncState.Suspending)
+        IsSuspended = _instance.GetAsyncState() == AsyncState.Suspending;
+        if (IsSuspended)
         {
-            IsSuspended = true;
-
             _stack = default;
             _stack = _instance.StopUnwind();
             return null;


### PR DESCRIPTION
```python
import time
time.sleep(0.1)  # Any value >0
```

```
Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Cannot access saved stack after it has been used once'.
   at Wazzy.Async.SavedStack.CheckEpoch()
   at Wazzy.Async.WasmAsyncExtensions.StartRewind(Instance instance, SavedStack stack)
   at Serpent.Python.Execute() in C:\Projects\C#\Serpent\Serpent\Python.cs:line 55
...
```