### PR TITLE
Interactive mode only when both code and file path are NOT set.

### DIFF
--- a/Serpent/PythonBuilder.cs
+++ b/Serpent/PythonBuilder.cs
@@ -126,7 +126,7 @@ public sealed class PythonBuilder
         private string? _pythonCachePath;
 
         private ReadOnlyMemory<byte>? _pythonCode;
-        private string _mainFilePath;
+        private string? _mainFilePath;
 
         internal InnerBuilder(Engine engine, Module module)
         {
@@ -147,7 +147,7 @@ public sealed class PythonBuilder
             _memorySize = 100_000_000;
 
             _pythonCode = default;
-            _mainFilePath = "main.py";
+            _mainFilePath = default;
         }
 
         /// <summary>
@@ -309,12 +309,15 @@ public sealed class PythonBuilder
             else
                 env.TryAdd("PYTHONDONTWRITEBYTECODE", "1");
 
+            var interactive = !(_pythonCode.HasValue || _mainFilePath != null);
+            _mainFilePath ??= "main.py";
+            
             // Tell it to run the python file.
             // argv[0] is the 'command used' which doesn't apply here, so we use a reasonable default.
             // argv[1] is the file path to run, omitting this would enter interactive mode and use stdin.
-            var environment = _pythonCode.HasValue
-                            ? new BasicEnvironment(env, [ "python", _mainFilePath ])
-                            : new BasicEnvironment(env, [ "python" ]);
+            var environment = interactive
+                            ? new BasicEnvironment(env, [ "python" ])
+                            : new BasicEnvironment(env, [ "python", _mainFilePath ]);
 
 
             // Build virtual filesystem

--- a/Serpent/PythonBuilder.cs
+++ b/Serpent/PythonBuilder.cs
@@ -18,7 +18,8 @@ public sealed class PythonBuilder
     : IDisposable
 {
     private const string EmbeddedWasmResourcePath = "Serpent.python3.13_async.wasm";
-
+    private const string DefaultPythonFileName = "main.py";
+    
     private readonly Module _module;
     private readonly Engine _engine;
 
@@ -310,14 +311,13 @@ public sealed class PythonBuilder
                 env.TryAdd("PYTHONDONTWRITEBYTECODE", "1");
 
             var interactive = !(_pythonCode.HasValue || _mainFilePath != null);
-            _mainFilePath ??= "main.py";
             
             // Tell it to run the python file.
             // argv[0] is the 'command used' which doesn't apply here, so we use a reasonable default.
             // argv[1] is the file path to run, omitting this would enter interactive mode and use stdin.
             var environment = interactive
                             ? new BasicEnvironment(env, [ "python" ])
-                            : new BasicEnvironment(env, [ "python", _mainFilePath ]);
+                            : new BasicEnvironment(env, [ "python", _mainFilePath ?? DefaultPythonFileName ]);
 
 
             // Build virtual filesystem
@@ -330,7 +330,7 @@ public sealed class PythonBuilder
                 dir.MapReadonlyZipArchiveDirectory("lib", archive);
 
                 if (_pythonCode != null)
-                    dir.CreateInMemoryFile(_mainFilePath, _pythonCode, isReadOnly: true);
+                    dir.CreateInMemoryFile(_mainFilePath ?? DefaultPythonFileName, _pythonCode, isReadOnly: true);
 
                 _fs(dir);
             });


### PR DESCRIPTION
Interactive mode should be the default if no code or main file path has been provided.

`WithMainFilePath` can be used to point to a different file which can be found in the virtual file system.
However you required `WithCode` to avoid interactive mode.